### PR TITLE
Remove doctrine/data-fixtures as a dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "behat/behat": "~3.0",
         "symfony/property-access": "~2.8",
         "doctrine/inflector": "~1.0",
-        "doctrine/data-fixtures": "~1.0",
         "behat/mink-extension": "~2.0",
         "fzaninotto/faker": "~1.4",
         "nelmio/alice": "~2.0",


### PR DESCRIPTION
I may be wrong, but I couldn't see an obvious use of `doctrine/data-fixtures` component by this component directly.

So let's see what happens in Travis if we remove it.